### PR TITLE
Added ContentSQLiteInteropFiles true to WPF csproj. Fixes #2.

### DIFF
--- a/Jukebox.WPF/Jukebox.WPF.csproj
+++ b/Jukebox.WPF/Jukebox.WPF.csproj
@@ -15,6 +15,10 @@
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+	<ContentSQLiteInteropFiles>true</ContentSQLiteInteropFiles>
+    <CopySQLiteInteropFiles>false</CopySQLiteInteropFiles>
+    <CleanSQLiteInteropFiles>false</CleanSQLiteInteropFiles>
+    <CollectSQLiteInteropFiles>false</CollectSQLiteInteropFiles>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>


### PR DESCRIPTION
The issue was one with how Visual Studio, it doesn't copy interop dll files by default to other csproj's (in this case, from the WPF to the base jukebox csproj), which resulted in the Jukebox throwing the error. The csproj is edited to tell Visual Studio to use the interop dll's when it builds the other csproj's in the solution.